### PR TITLE
adds onClick to 'tags' to search tag

### DIFF
--- a/src/components/common/ColTag.js
+++ b/src/components/common/ColTag.js
@@ -1,8 +1,12 @@
 import React from 'react';
 import { Col, Tag, Tooltip } from 'antd';
+import { connect } from 'react-redux';
+import { searchDocs } from '../../state/actions';
+import { useOktaAuth } from '@okta/okta-react';
 
 function ColTag(props) {
-  const { tag } = props;
+  const { searchDocs, tag } = props;
+  const { authState } = useOktaAuth();
 
   return (
     <Col
@@ -10,7 +14,12 @@ function ColTag(props) {
       span={6}
       style={{ display: 'flex', justifyContent: 'center' }}
     >
-      <Tag data-testid="doc-tag">
+      <Tag
+        data-testid="doc-tag"
+        onClick={() => {
+          searchDocs(tag, authState);
+        }}
+      >
         {tag.length < 8 ? (
           tag
         ) : (
@@ -21,4 +30,4 @@ function ColTag(props) {
   );
 }
 
-export default ColTag;
+export default connect(null, { searchDocs })(ColTag);


### PR DESCRIPTION
## Description

As a user, I can click a tag on the card and create a new search for that particular tag.

Connected the 'searchDocs' action to the tags per card.

[Video](https://www.loom.com/share/3d23a8b5276a41d89cc4237286c1f90a)

## Type of change

- [X] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes