### PR TITLE
bug/fixes the imports on landingcard.js AND adds opening fragment on landingcardlist.js

### DIFF
--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -1,8 +1,8 @@
 import React from 'react';
 import { Card } from 'antd';
 import { ArrowsAltOutlined } from '@ant-design/icons';
-import BookmarkOutlined from '../../../assets/OutlineBookMark.svg';
-import BookmarkFilled from '../../../assets/FilledBookMark.svg';
+import { ReactComponent as BookmarkOutlined } from '../../../assets/OutlineBookMark.svg';
+import { ReactComponent as BookmarkFilled } from '../../../assets/FilledBookMark.svg';
 import PropTypes from 'prop-types';
 import { Tags } from '../../common';
 import './LandingCard.css';
@@ -24,13 +24,7 @@ function LandingCard(props) {
             alt={name}
           />
         }
-        extra={
-          favorited ? (
-            <BookmarkFilled />
-          ) : (
-            <BookmarkOutlined />
-          )
-        }
+        extra={favorited ? <BookmarkFilled /> : <BookmarkOutlined />}
         style={{ width: 300 }}
         bodyStyle={{ padding: '12px' }}
       >

--- a/src/components/pages/Landing/LandingCardList.js
+++ b/src/components/pages/Landing/LandingCardList.js
@@ -6,14 +6,14 @@ import { Row, Col, Pagination } from 'antd';
 function LandingCardList(props) {
   const { docs } = props;
   return (
-
-    <Row gutter={{ xs: 16, sm: 24, md: 32, lg: 48 }} justify="center">
-      {docs.map(doc => (
-        <Col className="gutter-row" key={doc.box_id}>
-          <LandingCard {...doc} />
-        </Col>
-      ))}
-    </Row>
+    <>
+      <Row gutter={{ xs: 16, sm: 24, md: 32, lg: 48 }} justify="center">
+        {docs.map(doc => (
+          <Col className="gutter-row" key={doc.box_id}>
+            <LandingCard {...doc} />
+          </Col>
+        ))}
+      </Row>
       <Pagination />
     </>
   );


### PR DESCRIPTION
## Description
Upon pulling the latest copy of `main`, we had some errors rendering the page.
First, in landingcardlist.js, the opening fragment tag was missing.
Second, in landingcard.js, the svg's of the bookmark icon were not loading properly.
I consulted stackoverflow with the error and found that it might have something to do with a typescript error. I changed the import to be `{ReactComponent as BookmarkOutlined}` and all seems to be working.

I used crtl+click to follow the path of the svg's and noticed that it was all typescript, then used that tidbit to lead me to the correct stackoverflow article to fix it.

[Video](https://www.loom.com/share/15df723ae5f34c8d9e228a17cc41a49b)

Fixes # (issue)

Page was not loading due to a missing opening fragment and improper imports.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have removed unnecessary comments/console logs from my code
- [X] I have made corresponding changes to the documentation if necessary (optional)
- [X] My changes generate no new warnings
- [X] I have checked my code and corrected any misspellings
- [X] No duplicate code left within changed files
- [X] Size of pull request kept to a minimum
- [X] Pull request description clearly describes changes made & motivations for said changes