### PR TITLE
bookmark icon is filled on landing

### DIFF
--- a/src/state/actions/index.js
+++ b/src/state/actions/index.js
@@ -14,7 +14,6 @@ export const THUMBNAIL = 'THUMBNAIL';
 
 export const LIST_VIEW = 'LIST_VIEW';
 
-
 export const SEARCH = 'SEARCH';
 
 export const SET_DOCS = 'SET_DOCS';
@@ -30,7 +29,8 @@ export const getDocs = authState => async dispatch => {
     dispatch({ type: START_FETCH });
     const { data } = await axiosWithAuth(authState).get(`${apiURI}/bookmarks`);
     if (data.length > 0) {
-      dispatch({ type: SET_BOOKMARKS, payload: data });
+      const fileIds = data.map(d => d.fileId);
+      dispatch({ type: SET_BOOKMARKS, payload: fileIds });
       const ids = data.map(b => b.fileId).join(' ');
       const { Response } = await getDSData(`/search/${ids}`, authState);
       dispatch({ type: SET_DOCS, payload: Response });


### PR DESCRIPTION
## Description

Amy and I (Jennifer) noticed that when the page loaded that the bookmark icons were not filled in. This is a change so that the icons are filled in.

[video](https://www.loom.com/share/97e395ac5a6147e1aeda2f1477758fe5)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes