### PR TITLE
removed prop type warning

### DIFF
--- a/src/components/common/Header.js
+++ b/src/components/common/Header.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState, useEffect } from 'react';
 import Search from 'antd/es/input/Search';
 import { Avatar, Layout, Button } from 'antd';
 import { UserOutlined } from '@ant-design/icons';

--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -83,7 +83,7 @@ LandingCard.propTypes = {
   name: PropTypes.string.isRequired,
   url: PropTypes.string.isRequired,
   tags: PropTypes.arrayOf(PropTypes.string),
-  isFavorite: PropTypes.bool.isRequired,
+  isFavorite: PropTypes.bool,
 };
 
 const mapStateToProps = state => ({


### PR DESCRIPTION
## Description

Jennifer and I (Amy) removed the prop type warning for isFavorite in LandingCard.js by making it not a required value.

[[video](https://www.loom.com/share/3318dec803a14f029f7ede4835653c1e)]

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes