### PR TITLE
Bug/Bookmark Page Tag/Search Issues

### DIFF
--- a/src/components/common/ColTag/ColTag.js
+++ b/src/components/common/ColTag/ColTag.js
@@ -1,7 +1,11 @@
 import React from 'react';
 import { Col, Tag, Tooltip } from 'antd';
 import { connect } from 'react-redux';
-import { searchDocs, setCurrentSearch } from '../../../state/actions/searches';
+import {
+  searchDocs,
+  setCurrentSearch,
+  setPageToSearchResults,
+} from '../../../state/actions/searches';
 import { useOktaAuth } from '@okta/okta-react';
 
 function ColTag(props) {
@@ -18,6 +22,7 @@ function ColTag(props) {
         style={{ cursor: 'pointer' }}
         data-testid="doc-tag"
         onClick={() => {
+          setPageToSearchResults();
           searchDocs(tag, authState, 1, pageSize);
         }}
       >
@@ -35,6 +40,8 @@ const mapStateToProps = state => ({
   pageSize: state.searches.pageSize,
 });
 
-export default connect(mapStateToProps, { searchDocs, setCurrentSearch })(
-  ColTag
-);
+export default connect(mapStateToProps, {
+  searchDocs,
+  setCurrentSearch,
+  setPageToSearchResults,
+})(ColTag);

--- a/src/components/common/Header/Header.js
+++ b/src/components/common/Header/Header.js
@@ -69,7 +69,7 @@ function MainHeader(props) {
       setQuery('');
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [currentSearch]);
+  }, [pageType, currentSearch]);
 
   const changeHandler = e => {
     setQuery(e.target.value);

--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -125,7 +125,6 @@ function LandingCard(props) {
           <Tags tagArray={tags} size={8} />
         </Card>
       )}
-      ;
     </>
     //       )
     //     }

--- a/src/components/pages/Landing/LandingCardResults.js
+++ b/src/components/pages/Landing/LandingCardResults.js
@@ -30,14 +30,14 @@ function LandingCardResults(props) {
     // for when the page size stays the same
     if (pageSize === props.pageSize) {
       setCurrentSearch(currentSearch, page, pageSize);
-      searchDocs(currentSearch, authState, page, props.pageSize);
+      searchDocs(currentSearch, authState, page, props.pageSize, pageType);
     }
     // when page size changes, this keeps track of where you were
     else {
       const newPage =
         Math.floor(((currentPage - 1) * props.pageSize + 1) / pageSize) + 1;
       setCurrentSearch(currentSearch, newPage, pageSize);
-      searchDocs(currentSearch, authState, newPage, pageSize);
+      searchDocs(currentSearch, authState, newPage, pageSize, pageType);
     }
   };
 

--- a/src/state/actions/searches.js
+++ b/src/state/actions/searches.js
@@ -14,7 +14,8 @@ export const searchDocs = (
   search,
   authState,
   page = 1,
-  pageSize
+  pageSize,
+  pageType
 ) => dispatch => {
   dispatch({ type: START_FETCH });
   dispatch({ type: SET_SEARCH_QUERY, payload: search });
@@ -29,7 +30,13 @@ export const searchDocs = (
         dispatch({ type: FINISH_FETCH });
       } else {
         dispatch({ type: SET_DOCS, payload: data });
-        setCurrentSearch(search, page, pageSize);
+        dispatch({
+          type: CURRENT_SEARCH,
+          payload: { currentSearch: search, currentPage: page, pageSize },
+        });
+        if (pageType !== 'bookmarks') {
+          dispatch({ type: SET_PAGE, payload: 'searchResults' });
+        }
       }
     })
     .catch(console.error);


### PR DESCRIPTION
## Description

Amy, Klove, and I (Michael) addressed the following--
When a user is on the bookmarks page, if they clicked on a tag, the search-bar didn't populate with the new search.
If on bookmarks, and not page 1, page number didn't update upon a search-bar search or tag search.
We also removed rendered semicolons.

[Video](https://www.loom.com/share/98fe360d6da6407ea8caf1f70fe266ae)
## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes