### PR TITLE
Feature/adjust card title

### DIFF
--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -108,7 +108,7 @@ function LandingCard(props) {
         >
           <Row wrap="false">
             <Col span={2}>
-              <Row style={{ marginTop: 10, marginBottom: 15 }}>
+              <Row style={{ marginTop: 8, marginBottom: 15 }}>
                 <Tooltip title="Document Summary">
                   <SummaryModal name={name} summary={summary} />
                 </Tooltip>

--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -61,7 +61,7 @@ function LandingCard(props) {
         // displays the results in card view
         <Card
           title={
-            <Row style={{ marginLeft: 5 }}>
+            <Row style={{ marginLeft: 15 }}>
               <Col
                 span={18}
                 style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}
@@ -108,15 +108,19 @@ function LandingCard(props) {
         >
           <Row wrap="false">
             <Col span={2}>
-              <Tooltip title="Document Summary">
-                <SummaryModal name={name} summary={summary} />
-              </Tooltip>
-              <Tooltip title="Add/Edit Tags">
-                <EditTags
-                  style={{ fontSize: 18, cursor: 'pointer' }}
-                  onClick={loadTagModal}
-                />
-              </Tooltip>
+              <Row style={{ marginTop: 10, marginBottom: 15 }}>
+                <Tooltip title="Document Summary">
+                  <SummaryModal name={name} summary={summary} />
+                </Tooltip>
+              </Row>
+              <Row>
+                <Tooltip title="Add/Edit Tags">
+                  <EditTags
+                    style={{ fontSize: 18, cursor: 'pointer' }}
+                    onClick={loadTagModal}
+                  />
+                </Tooltip>
+              </Row>
             </Col>
             <Col span={22}>
               <Tags tagArray={tags} size={8} />


### PR DESCRIPTION
## Description

per our product review meeting yesterday, this feature adjusts the left margin of the title of the card so that its left alignment matches the buttons on the bottom of the card. This also increases the spacing of the summary and tag-modal icons to better fill the space

[video](https://www.loom.com/share/ca8735cee77448fbb8d7b34dc1190253)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes