### PR TITLE
Feature/save button tag modal

### DIFF
--- a/src/components/common/TagModal.js
+++ b/src/components/common/TagModal.js
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import Querystring from 'querystring';
 import { connect } from 'react-redux';
 import { Modal, Input as Add, Tag, Tooltip, Row, Col, Button } from 'antd';
+import { PlusCircleFilled } from '@ant-design/icons';
 import {
   handleModal,
   setDocTags,
@@ -90,6 +91,12 @@ function TagModal(props) {
             onPressEnter={handleAdd}
             value={newTag}
             onChange={changeHandler}
+          />
+        </Col>
+        <Col span={2}>
+          <PlusCircleFilled
+            onClick={handleAdd}
+            style={{ fontSize: 18, marginTop: 5 }}
           />
         </Col>
       </Row>

--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -108,7 +108,7 @@ function LandingCard(props) {
         >
           <Row wrap="false">
             <Col span={2}>
-              <Row style={{ marginTop: 10, marginBottom: 15 }}>
+              <Row style={{ marginTop: 8, marginBottom: 15 }}>
                 <Tooltip title="Document Summary">
                   <SummaryModal name={name} summary={summary} />
                 </Tooltip>

--- a/src/components/pages/Landing/LandingCard.js
+++ b/src/components/pages/Landing/LandingCard.js
@@ -61,7 +61,7 @@ function LandingCard(props) {
         // displays the results in card view
         <Card
           title={
-            <Row style={{ marginLeft: 5 }}>
+            <Row style={{ marginLeft: 15 }}>
               <Col
                 span={18}
                 style={{ textOverflow: 'ellipsis', overflow: 'hidden' }}
@@ -108,15 +108,19 @@ function LandingCard(props) {
         >
           <Row wrap="false">
             <Col span={2}>
-              <Tooltip title="Document Summary">
-                <SummaryModal name={name} summary={summary} />
-              </Tooltip>
-              <Tooltip title="Add/Edit Tags">
-                <EditTags
-                  style={{ fontSize: 18, cursor: 'pointer' }}
-                  onClick={loadTagModal}
-                />
-              </Tooltip>
+              <Row style={{ marginTop: 10, marginBottom: 15 }}>
+                <Tooltip title="Document Summary">
+                  <SummaryModal name={name} summary={summary} />
+                </Tooltip>
+              </Row>
+              <Row>
+                <Tooltip title="Add/Edit Tags">
+                  <EditTags
+                    style={{ fontSize: 18, cursor: 'pointer' }}
+                    onClick={loadTagModal}
+                  />
+                </Tooltip>
+              </Row>
             </Col>
             <Col span={22}>
               <Tags tagArray={tags} size={8} />


### PR DESCRIPTION
## Description

This feature adds a save button to the Add tag input button in the tag modal. While demoing the add tag feature our group realized that we needed to better guide the user to know how to add a tag.

[video](https://www.loom.com/share/d00dc612366a4b17be7bd27360000ba1)

Fixes # (issue)
Clarifies possible confusion when user is attempting to add a tag.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have removed unnecessary comments/console logs from my code
- [x] My changes generate no new warnings
- [x] I have checked my code and corrected any misspellings
- [x] No duplicate code left within changed files
- [x] Size of pull request kept to a minimum
- [x] Pull request description clearly describes changes made & motivations for said changes